### PR TITLE
Prefix include directory

### DIFF
--- a/concurrentqueue/buildfile
+++ b/concurrentqueue/buildfile
@@ -15,4 +15,4 @@ hxx{*}:
   install.subdirs = true
 }
 
-lib{concurrentqueue}: cxx.pkgconfig.include = include/concurrentqueue/
+lib{concurrentqueue}: cxx.pkgconfig.include = include/ include/concurrentqueue/

--- a/concurrentqueue/buildfile
+++ b/concurrentqueue/buildfile
@@ -8,3 +8,11 @@ if ($cxx.target.class != 'windows')
     cxx.libs += "-lpthread"
     lib{concurrentqueue}: cxx.export.libs += "-lpthread"
 }
+
+hxx{*}:
+{
+  install         = include/concurrentqueue/
+  install.subdirs = true
+}
+
+lib{concurrentqueue}: cxx.pkgconfig.include = include/concurrentqueue/

--- a/concurrentqueue/buildfile
+++ b/concurrentqueue/buildfile
@@ -1,6 +1,6 @@
 lib{concurrentqueue}: hxx{*}
 {
-  cxx.export.poptions += "-I$src_base"
+  cxx.export.poptions += "-I$src_base" "-I$src_root"
 }
 
 if ($cxx.target.class != 'windows')

--- a/tests/driver/unittests.cpp
+++ b/tests/driver/unittests.cpp
@@ -30,7 +30,7 @@ void operator delete(void* ptr, MakeSureCustomNewCanPeacefullyCoexist* x);
 #include <common/simplethread.h>
 #include <common/systemtime.h>
 #include <concurrentqueue.h>
-#include <blockingconcurrentqueue.h>
+#include <concurrentqueue/blockingconcurrentqueue.h>
 
 namespace {
 	struct tracking_allocator


### PR DESCRIPTION
## Install the headers inside a subdirectory called concurrentqueue/
Upstream does not do this but since is quite a standardized way of doing it I propose supporting both ways. so `<concurrentqueue.h>` and `<concurrentqueue/concurrentqueue.h>` works.
Queued CI here https://ci.cppget.org/@5fd83f68-de25-48c7-b16f-5d54f9181cbd